### PR TITLE
Add `include-css` option

### DIFF
--- a/src/stylus-to-css.ts
+++ b/src/stylus-to-css.ts
@@ -33,6 +33,10 @@ export default function stylusToCss(content: string, options: Options): Promise<
 			options.use.forEach(it => styl.use(it))
 		}
 
+		if (options.includeCss) {
+			styl.set('include css', true)
+		}
+
 		if (options.sourcemap) {
 			styl.set('sourcemap', {
 				comment: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,5 @@ export interface StylusOptions {
 	include?: string[]
 	define?: ([string, any, boolean?])[]
 	use?: ((styl: any) => void)[]
+	includeCss?: boolean
 }


### PR DESCRIPTION
Thanks for the loader :)

Just needed this extra setting for my project to match the `--include-css` cmd line option

eg:

```
const { build } = require('esbuild')
const { stylusLoader } = require('esbuild-stylus-loader')

build({
  ...
  plugins: [
    stylusLoader({
      stylusOptions: {
        includeCss: true,
      },
    }),
  ],
})
```